### PR TITLE
[fix] app.debug() logs twice

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,7 +45,7 @@ module.exports = logger => {
 
       debug() {
         if (this._logger && typeof this._logger.debug === 'function') {
-          this._logger.debug.apply(this._logger, arguments);
+          return this._logger.debug.apply(this._logger, arguments);
         }
 
         return console.error('DEBUG: ', arguments);


### PR DESCRIPTION
Now a `return` is missing in `debug()`, so all `app.debug()` is logging the same thing twice, first via winston, then via console.error.
